### PR TITLE
enh: added github oauth example

### DIFF
--- a/json_api/brainspell.py
+++ b/json_api/brainspell.py
@@ -459,7 +459,7 @@ def make_app():
         (r"/bulk-add", BulkAddHandler),
         (r"/save-article", SaveArticleHandler),
         (r"/oauth", GithubLoginHandler),
-        (r"/github_logout", GithubLogoutHandler)
+        (r"/github_logout", GithubLogoutHandler),
         (r"/save-collection", SaveCollectionHandler)
     ], debug=True, **settings)
 

--- a/json_api/brainspell.py
+++ b/json_api/brainspell.py
@@ -391,8 +391,13 @@ if "COOKIE_SECRET" in os.environ:
     public_key = os.environ["COOKIE_SECRET"]
 assert public_key is not None, "The environment variable \"COOKIE_SECRET\" needs to be set."
 
-assert "github_client_id" in os.environ, "set your github_client_id env variable, and register your app at https://github.com/settings/developers"
-assert "github_client_secret" in os.environ, "set your github_client_secret env variable, and register your app at https://github.com/settings/developers"
+
+if not "github_client_id" in os.environ:
+    print("set your github_client_id env variable, and register your app at https://github.com/settings/developers")
+    os.environ["github_client_id"] = "gh_client_id"
+if not "github_client_secret" in os.environ:
+    print("set your github_client_secret env variable, and register your app at https://github.com/settings/developers")
+    os.environ["github_client_secret"] = "github_client_secret"
 
 
 settings = {

--- a/json_api/brainspell.py
+++ b/json_api/brainspell.py
@@ -124,7 +124,9 @@ class ArticleHandler(BaseHandler):
             articleId = self.get_query_argument("id")
         except:
             self.redirect("/") # id wasn't passed; redirect to home page
+        gh_user = self.get_current_github_user()
         self.render("static/html/view-article.html", id=articleId,
+            github_user=gh_user["name"], github_avatar=gh_user["avatar_url"],
             title=self.get_current_email())
     def post(self): # TODO: maybe make its own endpoint (probably more appropriate than overloading this one)
         id = self.get_body_argument('id')
@@ -372,7 +374,7 @@ class SaveCollectionHandler(BaseHandler):
             articles_decoded = []
             for a in articles_encoded:
                 article = a.decode('utf-8') # TODO: move save article operations to models.py
-                User_metadata.insert(user_id = self.get_current_email(), 
+                User_metadata.insert(user_id = self.get_current_email(),
                     article_pmid = article, collection = collection_name).execute()
         else:
             pass

--- a/json_api/static/html/index.html
+++ b/json_api/static/html/index.html
@@ -82,8 +82,19 @@
                     </li>
                 </ul>
                 {% if title!="" %}
-                    <a href="./account" class="navbar-brand navbar-right"style="font-size:1em;">Welcome {{ title }}</a>
+                    <a href="./account" class="navbar-brand navbar-right" style="font-size:1em;">Welcome {{ title }}</a>
                 {% end %}
+                {% if github_user %}
+                <img class="navbar-brand navbar-right img-circle" src="{{github_avatar}}"/>
+                <div class="navbar-brand navbar-right" style="font-size:1em;">
+                  Welcome {{ github_user }}, <a href="/github_logout">logout</a>
+                </div>
+                {% else %}
+                <div class="navbar-brand navbar-right" style="font-size:1em;">
+                  <a href="/oauth">login with GitHub</a>
+                </div>
+                {% end %}
+
             </div>
             <!-- /.navbar-collapse -->
         </div>
@@ -145,7 +156,7 @@
         $("#randomResults").append($("<p>").css("color", "#c0c0c0").text("Loading..."));
         $(
             $.ajax({
-                type: "GET", 
+                type: "GET",
                 url: "/json/random-query"
             }).complete(function(o) {
                 j = o.responseText;

--- a/json_api/static/html/view-article.html
+++ b/json_api/static/html/view-article.html
@@ -92,6 +92,16 @@
                 {% if title!="" %}
                     <a href="./account" class="navbar-brand navbar-right"style="font-size:1em;">Welcome {{ title }}</a>
                 {% end %}
+                {% if github_user %}
+                <img class="navbar-brand navbar-right img-circle" src="{{github_avatar}}"/>
+                <div class="navbar-brand navbar-right" style="font-size:1em;">
+                  Welcome {{ github_user }}, <a href="/github_logout">logout</a>
+                </div>
+                {% else %}
+                <div class="navbar-brand navbar-right" style="font-size:1em;">
+                  <a href="/oauth">login with GitHub</a>
+                </div>
+                {% end %}
             </div>
             <!-- /.navbar-collapse -->
         </div>
@@ -460,7 +470,7 @@
 
 
             $.ajax({
-                type: "POST", 
+                type: "POST",
                 url: "/view-article",
                 data: {
                     "dbChanges": changes,

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ psycopg2==2.6.2
 pytest==3.0.3
 pytest-tornado==0.4.5
 lxml==3.3.6
+tornigithub==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ psycopg2==2.6.2
 pytest==3.0.3
 pytest-tornado==0.4.5
 lxml==3.3.6
-tornigithub==0.2.0
+torngithub==0.2.0


### PR DESCRIPTION
Hello,

I've added an example of using github OAuth. I had to revert back to a previous commit because I was getting another weird error when trying to run locally. To get this to work:

1. see change in requirements.txt -- make sure you `pip install torngithub`
2. make sure you register the application at https://github.com/settings/developers, and set the Authorization callback URL to http://localhost:5000. 
3. Then set your `github_client_id` and `github_client_secret` environment variables before running `brainspell.py`

It might be worth replacing your accounts handler with GitHub -- less code to maintain!
 