### PR TITLE
Introduces Caching to the GetUserCollectionsEndpoint

### DIFF
--- a/brainspell/json_api.py
+++ b/brainspell/json_api.py
@@ -473,7 +473,8 @@ class GetUserCollectionsEndpointHandler(BaseHandler):
         # Get all repositories owned by this user, and return the names that start with
         # brainspell-neo-collection.
         if args['cache']:
-            response["collections"] = get_brainspell_collections_from_api_key(args['key'])
+            response["collections"] = get_brainspell_collections_from_api_key(
+                args['key'])
             return response
 
         brainspell_repos = []
@@ -559,7 +560,7 @@ class GetUserCollectionsEndpointHandler(BaseHandler):
 
         response["collections"] = user_collections
         # TODO: Potentially make db updates like these Async: peewee-async
-        cache_user_collections(args['key'],user_collections)
+        cache_user_collections(args['key'], user_collections)
         return response
 
 

--- a/brainspell/json_api.py
+++ b/brainspell/json_api.py
@@ -458,6 +458,11 @@ class GetUserCollectionsEndpointHandler(BaseHandler):
             "type": int,
             "default": 0,
             "description": "1 if you want contributors information for each repo, 0 otherwise."
+        },
+        "cache": {
+            "type": int,
+            "default": 1,
+            "description": "1 if you want to retrieve cached UserCollectionInformation from Brainspell's DB, 0 otherwise"
         }
     }
 
@@ -467,8 +472,10 @@ class GetUserCollectionsEndpointHandler(BaseHandler):
     def process(self, response, args):
         # Get all repositories owned by this user, and return the names that start with
         # brainspell-neo-collection.
+        if args['cache']:
+            response["collections"] = get_brainspell_collections_from_api_key(args['key'])
+            return response
 
-        user = get_github_username_from_api_key(args['key'])
         brainspell_repos = []
         contributors_info = {}
         page_number = 1
@@ -551,6 +558,8 @@ class GetUserCollectionsEndpointHandler(BaseHandler):
             user_collections.append(single_collection)
 
         response["collections"] = user_collections
+        # TODO: Potentially make db updates like these Async: peewee-async
+        cache_user_collections(args['key'],user_collections)
         return response
 
 

--- a/brainspell/search_helpers.py
+++ b/brainspell/search_helpers.py
@@ -49,7 +49,7 @@ def parse_helper(query):
         columns.append(Articles.pmid)
     if tiab.search(query):
         columns.extend([Articles.title, Articles.abstract])
-    formatted_query = re.sub('\[.*\]', '', query).strip().replace(" ", "%")
+    formatted_query = re.sub(r'\[.*\]', '', query).strip().replace(" ", "%")
     if not columns:
         return (None, None, formatted_query)
     matches = [Match(col, formatted_query) for col in columns]

--- a/brainspell/user_account_helpers.py
+++ b/brainspell/user_account_helpers.py
@@ -262,4 +262,3 @@ def cache_user_collections(api_key, collections_obj):
         collections=json.dumps(collections_obj)).where(
             User.password == api_key)
     q.execute()
-

--- a/brainspell/user_account_helpers.py
+++ b/brainspell/user_account_helpers.py
@@ -253,3 +253,13 @@ def remove_article_from_brainspell_database_collection(
             User.password == api_key)
         q.execute()
     return True
+
+
+def cache_user_collections(api_key, collections_obj):
+    """ Force overwrite the existing user collection field with
+    the passed collections_object data.  """
+    q = User.update(
+        collections=json.dumps(collections_obj)).where(
+            User.password == api_key)
+    q.execute()
+


### PR DESCRIPTION
**Summary**
Introducing Caching to the GetUserCollectionsEndpoint. 

Simply taking the relevant JSON output from the getCollections method when called without caching parameters and storing this data into Brainspell DB. Force updates can be called by setting caching parameter = 0 and cached data is read using Caching parameter = 1. 


**Test Plan** 
- Loaded brainspell-neo-frontend and set get-user-collections endpoint to: `axios.get(http://localhost:5000/json/v2/get-user-collections?key=${key}&github_token=${token}&contributors=0&cache=1)`
Has to be run initially with Cache parameter set to False to update Brainspell DB and then pulls from DB on subsequent runs. Further verified heroku build still functions as before with update. 

