### PR TITLE
Websocket functionality

### DIFF
--- a/brainspell/base_handler.py
+++ b/brainspell/base_handler.py
@@ -368,6 +368,7 @@ class BaseHandler(tornado.web.RequestHandler):
             route = route[1:]
         if data:
             data = json.dumps(data)
+
         result = f(
             "https://api.github.com/{0}".format(route),
             data=data,

--- a/brainspell/base_handler.py
+++ b/brainspell/base_handler.py
@@ -368,7 +368,6 @@ class BaseHandler(tornado.web.RequestHandler):
             route = route[1:]
         if data:
             data = json.dumps(data)
-
         result = f(
             "https://api.github.com/{0}".format(route),
             data=data,

--- a/brainspell/json_api.py
+++ b/brainspell/json_api.py
@@ -456,9 +456,9 @@ class GetUserCollectionsEndpointHandler(BaseHandler):
 
         while more_repos:
             repos_list = await BaseHandler.github_request(self, f=GET,
-                                                   route="user/repos?per_page=100&page={0}".format(page_number),
-                                                   token=args["github_token"],
-                                                   data={"affiliation": "owner"})
+                                                          route="user/repos?per_page=100&page={0}".format(page_number),
+                                                          token=args["github_token"],
+                                                          data={"affiliation": "owner"})
 
             if len(repos_list) == 0:
                 more_repos = False
@@ -482,10 +482,10 @@ class GetUserCollectionsEndpointHandler(BaseHandler):
 
         for name, url in brainspell_repos:
             repo_req = await BaseHandler.github_request(self, GET,
-                                                 url.replace(
-                                                     "https://api.github.com/",
-                                                     "") + "/contents/metadata.json",
-                                                 args["github_token"])
+                                                        url.replace(
+                                                            "https://api.github.com/",
+                                                            "") + "/contents/metadata.json",
+                                                        args["github_token"])
             repo_meta = decode_from_github(repo_req["content"])
 
             # Convert PeeWee article object to dict

--- a/brainspell/json_api.py
+++ b/brainspell/json_api.py
@@ -455,10 +455,10 @@ class GetUserCollectionsEndpointHandler(BaseHandler):
         more_repos = True
 
         while more_repos:
-            repos_list = await self.github_request(GET,
-                                                   "user/repos?per_page=100&page={0}".format(page_number),
-                                                   args["github_token"],
-                                                   {"affiliation": "owner"})
+            repos_list = await BaseHandler.github_request(self, f=GET,
+                                                   route="user/repos?per_page=100&page={0}".format(page_number),
+                                                   token=args["github_token"],
+                                                   data={"affiliation": "owner"})
 
             if len(repos_list) == 0:
                 more_repos = False
@@ -481,7 +481,7 @@ class GetUserCollectionsEndpointHandler(BaseHandler):
         user_collections = []
 
         for name, url in brainspell_repos:
-            repo_req = await self.github_request(GET,
+            repo_req = await BaseHandler.github_request(self, GET,
                                                  url.replace(
                                                      "https://api.github.com/",
                                                      "") + "/contents/metadata.json",

--- a/brainspell/websockets.py
+++ b/brainspell/websockets.py
@@ -1,6 +1,7 @@
 import json
 
 import tornado.websocket
+import threading
 
 import json_api
 from article_helpers import *
@@ -9,6 +10,9 @@ from user_account_helpers import *
 
 first_cap_re = re.compile('(.)([A-Z][a-z]+)')
 all_cap_re = re.compile('([a-z0-9])([A-Z])')
+
+# Seconds between heartbeat messages for long running web-socket based computation
+HEARTBEAT_INTERVAL = 15
 
 
 def convert(name):
@@ -33,15 +37,28 @@ class EndpointWebSocket(tornado.websocket.WebSocketHandler):
 
     def open(self):
         # setup
+        print("OPENED CONNECTION")
         pass
 
-    def on_message(self, message):
+    def check_origin(self, origin):
+        if not "PRODUCTION_FLAG" in os.environ:
+            return True
+        allowed_origins = {"https://brainspell.herokuapp.com", "https://metacurious.org"}
+        return any([origin.startswith(org) for org in allowed_origins])
+
+    def issue_periodic_write(self, f_stop):
+        if not f_stop.is_set():
+            self.write_message(
+                json.dumps({"loading": 1})
+            )
+            threading.Timer(HEARTBEAT_INTERVAL, self.issue_periodic_write, [f_stop]).start()
+
+    async def on_message(self, message):
         """
         Receive a JSON formatted message, parse the arguments,
         and pass the resulting arguments dictionary to the processing
         function of the corresponding JSON API class. Return the response.
         """
-
         messageDict = json.loads(message)
 
         if messageDict["type"] not in endpoints:
@@ -55,7 +72,15 @@ class EndpointWebSocket(tornado.websocket.WebSocketHandler):
             if "payload" in messageDict:
                 payload = messageDict["payload"]
 
-            self.write_message(json.dumps(api_call(func, payload)))
+            # Initialize long running compute messages
+            f_stop = threading.Event()
+            self.issue_periodic_write(f_stop)
+
+            res = await api_call(func, payload)
+
+            f_stop.set()
+
+            self.write_message(json.dumps(res))
 
     def on_close(self):
         # cleanup

--- a/brainspell/websockets.py
+++ b/brainspell/websockets.py
@@ -11,7 +11,8 @@ from user_account_helpers import *
 first_cap_re = re.compile('(.)([A-Z][a-z]+)')
 all_cap_re = re.compile('([a-z0-9])([A-Z])')
 
-# Seconds between heartbeat messages for long running web-socket based computation
+# Seconds between heartbeat messages for long running web-socket based
+# computation
 HEARTBEAT_INTERVAL = 15
 
 
@@ -37,13 +38,14 @@ class EndpointWebSocket(tornado.websocket.WebSocketHandler):
 
     def open(self):
         # setup
-        print("OPENED CONNECTION")
         pass
 
     def check_origin(self, origin):
-        if not "PRODUCTION_FLAG" in os.environ:
+        if "PRODUCTION_FLAG" not in os.environ:
             return True
-        allowed_origins = {"https://brainspell.herokuapp.com", "https://metacurious.org"}
+        allowed_origins = {
+            "https://brainspell.herokuapp.com",
+            "https://metacurious.org"}
         return any([origin.startswith(org) for org in allowed_origins])
 
     def issue_periodic_write(self, f_stop):
@@ -51,7 +53,10 @@ class EndpointWebSocket(tornado.websocket.WebSocketHandler):
             self.write_message(
                 json.dumps({"loading": 1})
             )
-            threading.Timer(HEARTBEAT_INTERVAL, self.issue_periodic_write, [f_stop]).start()
+            threading.Timer(
+                HEARTBEAT_INTERVAL,
+                self.issue_periodic_write,
+                [f_stop]).start()
 
     async def on_message(self, message):
         """


### PR DESCRIPTION
**Summary**
Long running computations especially for the `forcePullFromGithub` endpoints were timing out due to Heroku router limitations. Heroku prevents any single request from taking over 30 seconds if there are no updates posted to the client in that time. To get around this fact we are sending periodic messages to the client indicating the loading status of their query. 

Some method calls to `handle_github_request` were also encountering issues due to the way API_endpoint calls were structures so we switched to a different calling convention. 


**Test plan**
Tested on the `forcePullCollections` endpoint and validated that new data was transferred from github. 
